### PR TITLE
Bootstrappable FCMPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ ClangBuildAnalyzerSession.txt
 
 # guix
 /guix
+/cargo
 
 # Created by https://www.gitignore.io
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,3 @@
 [submodule "external/full-chain-membership-proofs"]
 	path = external/full-chain-membership-proofs
 	url = https://github.com/j-berman/full-chain-membership-proofs.git
-	branch = cpp-compat-ed25519

--- a/contrib/guix/cargo.scm
+++ b/contrib/guix/cargo.scm
@@ -1,0 +1,15 @@
+(use-modules (gnu packages)
+             (gnu packages bash)
+             ((gnu packages certs) #:select (nss-certs))
+             (gnu packages rust)
+             ((gnu packages tls) #:select (openssl)))
+
+(packages->manifest
+  (append
+    (list
+      bash
+      coreutils-minimal
+      nss-certs
+      openssl
+      rust
+      (list rust "cargo"))))

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -363,6 +363,21 @@ EOF
             exit 0
         fi
 
+        # Fetch cargo dependencies
+        time-machine environment --manifest="${PWD}/contrib/guix/cargo.scm" \
+                                 --container \
+                                 --pure \
+                                 --network \
+                                 --no-cwd \
+                                 --user="user" \
+                                 --share="$PWD"=/monero \
+                                 -- bash -c "cd /monero/external/full-chain-membership-proofs &&
+                                            cargo fetch &&
+                                            cd /monero/src/rust &&
+                                            cargo fetch &&
+                                            rm -rf /monero/cargo &&
+                                            mv /home/user/.cargo /monero/cargo"
+
         # Run the build script 'contrib/guix/libexec/build.sh' in the build
         # container specified by 'contrib/guix/manifest.scm'.
         #
@@ -434,6 +449,7 @@ EOF
                                  --pure \
                                  --no-cwd \
                                  --share="$PWD"=/monero \
+                                 --share="$PWD/cargo"=/home/user/.cargo \
                                  --share="$DISTSRC_BASE"=/distsrc-base \
                                  --share="$OUTDIR_BASE"=/outdir-base \
                                  --share="$LOGDIR_BASE"=/logdir-base \

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -138,6 +138,8 @@ case "$HOST" in
         export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GCC_LIB}/include-fixed:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
         export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
         export CROSS_LIBRARY_PATH="${CROSS_GCC_LIB_STORE}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib:${CROSS_GLIBC_STATIC}/lib"
+
+        export LD_LIBRARY_PATH="/gnu/store/6ncav55lbk5kqvwwflrzcr41hp5jbq0c-gcc-11.3.0-lib/lib"
         ;;
     *freebsd*)
         ;;

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -19,6 +19,7 @@
              (gnu packages perl)
              (gnu packages pkg-config)
              ((gnu packages python) #:select (python-minimal))
+             (gnu packages rust)
              ((gnu packages tls) #:select (openssl))
              ((gnu packages version-control) #:select (git-minimal))
              (guix build-system gnu)
@@ -249,6 +250,8 @@ chain for " target " development."))
         gperf
         gettext-minimal
         cmake-minimal
+        rust
+        `(,rust "cargo")
         ;; Native GCC 10 toolchain
         gcc-toolchain-10
         (list gcc-toolchain-10 "static")

--- a/src/rust/CMakeLists.txt
+++ b/src/rust/CMakeLists.txt
@@ -55,6 +55,8 @@ add_custom_command(
   VERBATIM
 )
 
+add_custom_target(rust_cxx ALL DEPENDS ${CXX_HEADER})
+
 set(monero_rust_sources ${MONERO_RUST_CXX})
 
 monero_find_all_headers(monero_rust_headers "${MONERO_RUST_HEADER_DIR}")

--- a/src/seraphis_core/CMakeLists.txt
+++ b/src/seraphis_core/CMakeLists.txt
@@ -48,9 +48,12 @@ set(seraphis_core_sources
 
 monero_find_all_headers(seraphis_core_headers, "${CMAKE_CURRENT_SOURCE_DIR}")
 
-monero_add_library(seraphis_core
-  ${seraphis_core_sources}
-  ${seraphis_core_headers})
+monero_add_library_with_deps(
+  NAME seraphis_core
+  DEPENDS rust_cxx
+  SOURCES
+    ${seraphis_core_sources}
+    ${seraphis_core_headers})
 
 target_link_libraries(seraphis_core
   PUBLIC

--- a/src/seraphis_crypto/CMakeLists.txt
+++ b/src/seraphis_crypto/CMakeLists.txt
@@ -40,9 +40,12 @@ set(seraphis_crypto_sources
 
 monero_find_all_headers(seraphis_crypto_headers, "${CMAKE_CURRENT_SOURCE_DIR}")
 
-monero_add_library(seraphis_crypto
-  ${seraphis_crypto_sources}
-  ${seraphis_crypto_headers})
+monero_add_library_with_deps(
+  NAME seraphis_crypto
+  DEPENDS rust_cxx
+  SOURCES
+    ${seraphis_crypto_sources}
+    ${seraphis_crypto_headers})
 
 target_link_libraries(seraphis_crypto
   PUBLIC

--- a/src/seraphis_impl/CMakeLists.txt
+++ b/src/seraphis_impl/CMakeLists.txt
@@ -41,9 +41,12 @@ set(seraphis_impl_sources
 
 monero_find_all_headers(seraphis_impl_headers, "${CMAKE_CURRENT_SOURCE_DIR}")
 
-monero_add_library(seraphis_impl
-  ${seraphis_impl_sources}
-  ${seraphis_impl_headers})
+monero_add_library_with_deps(
+  NAME seraphis_impl
+  DEPENDS rust_cxx
+  SOURCES
+    ${seraphis_impl_sources}
+    ${seraphis_impl_headers})
 
 target_link_libraries(seraphis_impl
   PUBLIC

--- a/src/seraphis_main/CMakeLists.txt
+++ b/src/seraphis_main/CMakeLists.txt
@@ -54,9 +54,12 @@ set(seraphis_main_sources
 
 monero_find_all_headers(seraphis_main_headers, "${CMAKE_CURRENT_SOURCE_DIR}")
 
-monero_add_library(seraphis_main
-  ${seraphis_main_sources}
-  ${seraphis_main_headers})
+monero_add_library_with_deps(
+  NAME seraphis_main
+  DEPENDS rust_cxx
+  SOURCES
+    ${seraphis_main_sources}
+    ${seraphis_main_headers})
 
 target_link_libraries(seraphis_main
   PUBLIC

--- a/src/seraphis_mocks/CMakeLists.txt
+++ b/src/seraphis_mocks/CMakeLists.txt
@@ -43,9 +43,12 @@ set(seraphis_mocks_sources
 
 monero_find_all_headers(seraphis_mocks_headers, "${CMAKE_CURRENT_SOURCE_DIR}")
 
-monero_add_library(seraphis_mocks
-  ${seraphis_mocks_sources}
-  ${seraphis_mocks_headers})
+monero_add_library_with_deps(
+  NAME seraphis_mocks
+  DEPENDS rust_cxx
+  SOURCES
+    ${seraphis_mocks_sources}
+    ${seraphis_mocks_headers})
 
 target_link_libraries(seraphis_mocks
   PUBLIC


### PR DESCRIPTION
This is based on #8929 and @j-berman's [fcmp branch](https://github.com/j-berman/monero/tree/fcmp).

Rust dependencies are fetched in a networked guix container and later bind-mounted into the build environment.

#### Notes:

- Rust 1.73

#### Targets:

| Target                 | Builds | Tested |
|------------------------|--------|--------|
| x86_64-linux-gnu       | 🮱     |        |
| arm-linux-gnueabihf    |      |        |
| aarch64-linux-gnu      |      |        |
| riscv64-linux-gnu      |      |        |
| i686-linux-gnu         |     |        |
| i686-w64-mingw32       |    |        |
| x86_64-w64-mingw32     |      |        |
| x86_64-unknown-freebsd |      |        |
| x86_64-apple-darwin    |     |        |
| aarch64-apple-darwin   |      |        |
| arm-linux-androideabi  |      |        |
| aarch64-linux-android  |      |        |